### PR TITLE
Require Julia 1.10; widen NonconvexCore compat; fix Random stdlib [compat]

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
-NonconvexCore = "1.5, 2"
+NonconvexCore = "1.5"
 Parameters = "0.12, 0.13"
 Random = "1"
 Reexport = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -10,11 +10,11 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
-NonconvexCore = "1.5"
+NonconvexCore = "1.5, 2"
 Parameters = "0.12, 0.13"
-Random = "1.11.0"
+Random = "1"
 Reexport = "1"
-julia = "1"
+julia = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Bumps Julia floor to 1.10; sort and widen [compat] entries.

Behavioral changes: none at runtime on currently-resolved Manifest. Verified via Pkg.resolve().

@JuliaNonconvex/maintainers pinging for review.